### PR TITLE
Implement Migrations

### DIFF
--- a/src/chaise/dictful.py
+++ b/src/chaise/dictful.py
@@ -21,6 +21,9 @@ class Document(dict):
     revs_info: list | None = None
     revisions: dict | None = None
 
+    def __repr__(self):
+        return f"<{type(self).__name__} {self.id!r}@{self.rev!r} {' '.join(f'{k}={v!r}' for k,v in self.items())}>"
+
 
 class BasicLoader:
     """

--- a/tests/dictful/conftest.py
+++ b/tests/dictful/conftest.py
@@ -55,18 +55,21 @@ class DictPool(chaise.SessionPool):
 def dict_models():
     @DictRegistry.document("Foo1")
     class AncientFoo(chaise.dictful.Document):
+        # spam is uppercase
         pass
 
     @DictRegistry.document("Foo2")
     class OldFoo(chaise.dictful.Document):
+        # spam is lowercase
         pass
 
     @DictRegistry.migration(AncientFoo, OldFoo)
     def foo1_migration(old):
-        return OldFoo(bar=old["bar"].upper())
+        return OldFoo(bar=old["bar"].lower())
 
     @DictRegistry.document("Foo3")
     class Foo(chaise.dictful.Document):
+        # spam is titlecase
         pass
 
     @DictRegistry.migration(OldFoo, Foo)

--- a/tests/dictful/conftest.py
+++ b/tests/dictful/conftest.py
@@ -53,12 +53,26 @@ class DictPool(chaise.SessionPool):
 
 @pytest.fixture(scope="session")
 def dict_models():
-    @DictRegistry.document("FooV1")
+    @DictRegistry.document("Foo1")
+    class OldFoo(chaise.dictful.Document):
+        pass
+
+    @DictRegistry.document("Foo2")
     class Foo(chaise.dictful.Document):
+        pass
+
+    @DictRegistry.migration(OldFoo, Foo)
+    def foo_migration(old):
+        return Foo(bar=old["bar"].title())
+
+    @DictRegistry.document("Counter")
+    class Counter(chaise.dictful.Document):
         pass
 
     return types.SimpleNamespace(
         Foo=Foo,
+        OldFoo=OldFoo,
+        Counter=Counter,
     )
 
 

--- a/tests/dictful/conftest.py
+++ b/tests/dictful/conftest.py
@@ -54,15 +54,23 @@ class DictPool(chaise.SessionPool):
 @pytest.fixture(scope="session")
 def dict_models():
     @DictRegistry.document("Foo1")
-    class OldFoo(chaise.dictful.Document):
+    class AncientFoo(chaise.dictful.Document):
         pass
 
     @DictRegistry.document("Foo2")
+    class OldFoo(chaise.dictful.Document):
+        pass
+
+    @DictRegistry.migration(AncientFoo, OldFoo)
+    def foo1_migration(old):
+        return OldFoo(bar=old["bar"].upper())
+
+    @DictRegistry.document("Foo3")
     class Foo(chaise.dictful.Document):
         pass
 
     @DictRegistry.migration(OldFoo, Foo)
-    def foo_migration(old):
+    def foo2_migration(old):
         return Foo(bar=old["bar"].title())
 
     @DictRegistry.document("Counter")
@@ -71,6 +79,7 @@ def dict_models():
 
     return types.SimpleNamespace(
         Foo=Foo,
+        AncientFoo=AncientFoo,
         OldFoo=OldFoo,
         Counter=Counter,
     )

--- a/tests/dictful/test_dictful.py
+++ b/tests/dictful/test_dictful.py
@@ -91,8 +91,17 @@ async def test_conflicting_mutate(dict_database, dict_models):
     assert doc["count"] == 2
 
 
-async def test_migration(dict_database, dict_models):
-    start = dict_models.AncientFoo(bar="spam")
+async def test_migration2(dict_database, dict_models):
+    start = dict_models.OldFoo(bar="spam")
+    await dict_database.attempt_put(start, "test")
+
+    end = await dict_database.get("test")
+    assert isinstance(end, dict_models.Foo)
+    assert end["bar"] == "Spam"
+
+
+async def test_migration3(dict_database, dict_models):
+    start = dict_models.AncientFoo(bar="SPAM")
     await dict_database.attempt_put(start, "test")
 
     end = await dict_database.get("test")

--- a/tests/dictful/test_dictful.py
+++ b/tests/dictful/test_dictful.py
@@ -92,7 +92,7 @@ async def test_conflicting_mutate(dict_database, dict_models):
 
 
 async def test_migration(dict_database, dict_models):
-    start = dict_models.OldFoo(bar="spam")
+    start = dict_models.AncientFoo(bar="spam")
     await dict_database.attempt_put(start, "test")
 
     end = await dict_database.get("test")

--- a/tests/dictful/test_dictful.py
+++ b/tests/dictful/test_dictful.py
@@ -56,7 +56,7 @@ async def test_conflicting_mutate(dict_database, dict_models):
     """
     Test that a conflicting mutation works
     """
-    doc = dict_models.Foo(count=0)
+    doc = dict_models.Counter(count=0)
     await dict_database.attempt_put(doc, "test")
 
     # 1. Loser gets the doc
@@ -89,3 +89,12 @@ async def test_conflicting_mutate(dict_database, dict_models):
 
     doc = await dict_database.get("test")
     assert doc["count"] == 2
+
+
+async def test_migration(dict_database, dict_models):
+    start = dict_models.OldFoo(bar="spam")
+    await dict_database.attempt_put(start, "test")
+
+    end = await dict_database.get("test")
+    assert isinstance(end, dict_models.Foo)
+    assert end["bar"] == "Spam"


### PR DESCRIPTION
This implements deterministic implicit migrations. By which I mean:

* Migrations are performed automatically on document load
* Registering two migrations against the same starting class is disallowed