### PR TITLE
Add doc object support to Database.mutate()

### DIFF
--- a/src/chaise/__init__.py
+++ b/src/chaise/__init__.py
@@ -348,6 +348,19 @@ class Database:
             pass
         return blob, db, docid, etag
 
+    def _doc_details(self, doc):
+        """
+        Like _doc2blob but doesn't do the blob work
+        """
+        db = docid = etag = None
+        try:
+            db = doc.__db
+            docid = doc.__docid
+            etag = doc.__etag
+        except AttributeError:
+            pass
+        return db, docid, etag
+
     def _touch_doc(self, doc, *, db=None, etag=None, rev=None, id=None):
         fields = {}
         if etag is not None:
@@ -529,7 +542,7 @@ class Database:
 
         See :http:delete:`/{db}/{docid}`
         """
-        _, db, docid, etag = self._doc2blob(doc)
+        db, docid, etag = self._doc_details(doc)
         assert db == self._name
         assert docid
         await self._session._request(
@@ -552,7 +565,7 @@ class Database:
         """
         # FIXME: Figure out signature
 
-    async def mutate(self, docid: str) -> AsyncIterator:
+    async def mutate(self, id_or_doc: str | object) -> AsyncIterator:
         """
         A document mutation loop::
 
@@ -560,8 +573,17 @@ class Database:
                 doc.foo = "bar"
 
         Will replay the mutation until it goes through.
+
+        Also accepts a previously-gotten document.
         """
-        doc = await self.get(docid)
+        if isinstance(id_or_doc, str):
+            docid = id_or_doc
+            doc = await self.get(id_or_doc)
+        else:
+            doc = id_or_doc
+            db, docid, _ = self._doc_details(doc)
+            assert db == self._name
+        assert docid
         while True:
             yield doc
             try:

--- a/tests/dictful/test_basic.py
+++ b/tests/dictful/test_basic.py
@@ -57,6 +57,23 @@ async def test_simple_mutate(basic_database):
     assert doc["spam"] == "foobar"
 
 
+async def test_mutate_existing(basic_database):
+    """
+    Test a mutation on a document object
+    """
+    doc = Document(spam="eggs")
+    await basic_database.attempt_put(doc, "test")
+    r1 = doc.rev
+
+    async for doc in basic_database.mutate(doc):
+        doc["spam"] = "foobar"
+
+    assert doc.rev != r1
+
+    doc = await basic_database.get("test")
+    assert doc["spam"] == "foobar"
+
+
 async def test_conflicting_mutate(basic_database):
     """
     Test that a conflicting mutation works


### PR DESCRIPTION
Supports flows like:

```
doc = db.get("spam")

# do stuff

async for doc in db.mutate(doc):
    ...
```

Fixes #66 